### PR TITLE
Create multiTx function

### DIFF
--- a/cosmospy/_transaction.py
+++ b/cosmospy/_transaction.py
@@ -55,6 +55,16 @@ class Transaction:
         }
         self._msgs.append(transfer)
 
+   def add_multi_transfer(self, data_inputF: str, data_outputF: str, denom: str = "uatom") -> None:
+	   transfer = {
+		   "type": "cosmos-sdk/MsgMultiSend",
+		   "value": {
+			   "inputs": data_inputF,
+			   "outputs": data_outputF
+            }
+        }
+        self._msgs.append(transfer)        
+        
     def get_pushable(self) -> str:
         pubkey = privkey_to_pubkey(self._privkey)
         base64_pubkey = base64.b64encode(pubkey).decode("utf-8")


### PR DESCRIPTION
I added a function that allows sending multi tx in a single block.
Here's how to use it: 

`data_input` is send
`data_output` is the one who receives 

```python
data_input = [{'address': 'cosmos1dwkhyqsgr6mxa2qf70rv5mpdch9vr345tsmlpm'
              , 'coins': [{'amount': '100000', 'denom': 'uatom'}]},
              {'address': 'cosmos1dwkhyqsgr6mxa2qf70rv5mpdch9vr345tsmlpm'
              , 'coins': [{'amount': '100000', 'denom': 'uatom'}]}]

data_output = [{'address': 'cosmos19xxs503q3xe6p20tngk4qa8shlp479739sly2z'
               , 'coins': [{'amount': '100000', 'denom': 'uatom'}]},
               {'address': 'cosmos1t8yky3wexwncwsdqvdet2e9l4drw69cwcgw3f0'
               , 'coins': [{'amount': '100000', 'denom': 'uatom'}]}]

tx.add_multi_transfer(data_inputF=data_input, data_outputF=data_output)

```
